### PR TITLE
Sentry error reporting

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -24,9 +24,6 @@
         <script src="https://www.gstatic.com/firebasejs/4.1.2/firebase-app.js"></script>
         <script src="https://www.gstatic.com/firebasejs/4.1.2/firebase-messaging.js"></script>
 
-        <!-- Sentry for error tracking -->
-        <script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous"></script>
-
         <!-- Amplitude analytics
         <script type="text/javascript">
           (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script");r.type="text/javascript";

--- a/client/index.html
+++ b/client/index.html
@@ -24,6 +24,9 @@
         <script src="https://www.gstatic.com/firebasejs/4.1.2/firebase-app.js"></script>
         <script src="https://www.gstatic.com/firebasejs/4.1.2/firebase-messaging.js"></script>
 
+        <!-- Sentry for error tracking -->
+        <script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous"></script>
+
         <!-- Amplitude analytics
         <script type="text/javascript">
           (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script");r.type="text/javascript";

--- a/client/scripts/app.js
+++ b/client/scripts/app.js
@@ -68,7 +68,7 @@ class Nametag extends Component {
     }
 
     // Attach user id to Sentry error reports
-    client.watchQuery({query: USER_QUERY}).subscribe({
+    client.watchQuery({query: USER_QUERY, fetchPolicy: 'cache-only'}).subscribe({
       next: ({data}) => {
         Raven.setUserContext({id: data.me.id})
       }

--- a/client/scripts/app.js
+++ b/client/scripts/app.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import Radium, {StyleRoot} from 'radium'
+import Raven from 'raven-js'
 
 import constants from './constants'
 import Room from './containers/Room/RoomContainer'

--- a/client/scripts/constants.js
+++ b/client/scripts/constants.js
@@ -41,5 +41,6 @@ export default {
 
   // Public keys and tokens
   FIREBASE_WEB_KEY: 'AIzaSyCkPlC2qRkXchd9AdubS6aAyvhE1TNAPqU',
-  FIREBASE_SENDER_ID: '820872076821'
+  FIREBASE_SENDER_ID: '820872076821',
+  SENTRY_DSN: 'https://3ef3bbac14984711984c884138df8474@sentry.io/195290'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,8 @@ nametag:
     - ./dist:/usr/client/
     - ./.keys:/usr/.keys
     - ./.hz:/usr/client/.hz
-    - ./server/src:/usr/server/src
-    - ./server/starthz.sh:/usr/server/starthz.sh
-    - ./server/backup.sh:/usr/server/backup.sh
-    - ./server/backup:/usr/server/backup
+    - .:/usr/nametag/
+    - ./server/backup:/usr/nametag/server/backup
   links:
     - rethinkdb
     - redis

--- a/nametagDockerfile
+++ b/nametagDockerfile
@@ -19,7 +19,6 @@ RUN pip install rethinkdb
 RUN pip install s3cmd
 
 LABEL yarnUpdated="5/25/17"
-COPY $PWD/server/package.json /usr/server/package.json
-WORKDIR usr/server
+WORKDIR /usr/nametag/server
 RUN yarn install
 CMD ./starthz.sh

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "moment": "^2.18.0",
     "qrcode.react": "^0.6.1",
     "radium": "^0.18.1",
+    "raven-js": "^3.17.0",
     "react": "^15.4.0",
     "react-addons-css-transition-group": "^15.3.2",
     "react-addons-update": "^15.4.2",

--- a/server/package.json
+++ b/server/package.json
@@ -41,6 +41,7 @@
     "passport-local": "^1.0.0",
     "passport-twitter": "^1.0.4",
     "pem": "^1.8.1",
+    "raven": "^2.1.0",
     "req-flash": "^0.0.3",
     "rethinkdb": "^2.1.1",
     "sendgrid": "^5.0.1",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const execSync = require('child_process').execSync
 const https = require('https')
 const fs = require('fs')
 const r = require('rethinkdb')
@@ -20,11 +21,21 @@ const passport = require('passport')
 const RedisStore = require('connect-redis')(session)
 const redis = require('./redis')
 const elasticsearch = require('./elasticsearch')
+const Raven = require('raven')
 const startSubscriptionServer = require('./graph/subscriptions/SubscriptionServer')
 const PORT = 8181
 
+const GIT_HASH = execSync('git rev-parse HEAD', {
+  cwd: path.join(__dirname, '../..')
+}).toString().trim()
+
 process.env.AWS_ACCESS_KEY_ID = config.s3.accessKeyId
 process.env.AWS_SECRET_ACCESS_KEY = config.s3.secretAccessKey
+
+Raven.config(config.sentry.dsn, {
+  tags: {git_commit: GIT_HASH},
+  environment: process.env.NODE_ENV
+}).install()
 
 const app = express()
 
@@ -34,6 +45,9 @@ const server = https.createServer({
   cert: fs.readFileSync(path.join('/', 'usr', '.keys', 'cert.pem')),
   ca: fs.readFileSync(path.join('/', 'usr', '.keys', 'chain.pem'))
 }, app).listen(PORT)
+
+/* Send errors to Sentry */
+app.use(Raven.requestHandler())
 
 /* Use body parser middleware */
 app.use(bodyParser.json())
@@ -144,6 +158,7 @@ r.connect({host: 'rethinkdb'})
       res.sendFile(path.join('/usr', 'client', 'public', 'index.html'))
     })
 
+    app.use(Raven.errorHandler())
     app.use('/', (err, req, res, next) => {
       if (err instanceof errors.APIError) {
         res.status(err.status)

--- a/server/src/secrets.sample.json
+++ b/server/src/secrets.sample.json
@@ -33,5 +33,8 @@
   },
   "elasticsearch": {
     "password": "supersecret"
+  },
+  "sentry": {
+    "dsn": "https://foo:bar@sentry.io/baz"
   }
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1196,7 +1196,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -1343,6 +1343,10 @@ lower-case@^1.1.1:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
 mailparser@^0.6.1:
   version "0.6.2"
@@ -1804,6 +1808,17 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.1.0.tgz#1b624e56374d9c9d93c74448461a2a356ce37527"
+  dependencies:
+    cookie "0.3.1"
+    json-stringify-safe "5.0.1"
+    lsmod "1.0.0"
+    stack-trace "0.0.9"
+    timed-out "4.0.1"
+    uuid "3.0.0"
+
 raw-body@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
@@ -2072,7 +2087,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.x:
+stack-trace@0.0.9, stack-trace@0.0.x:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
 
@@ -2171,6 +2186,10 @@ tar@^2.2.1:
 through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+timed-out@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timed-out@^2.0.0:
   version "2.0.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': {
         'VERSION': `"${require('./package.json').version}"`,
-        'CLIENT_GIT_HASH': GIT_HASH ? JSON.stringify(GIT_HASH) : null
+        'CLIENT_GIT_HASH': JSON.stringify(GIT_HASH)
       }
     }),
     new webpack.ExtendedAPIPlugin()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     path: path.join(__dirname, 'dist', 'public', 'scripts'),
     publicPath: '/public/',
     filename: '[name].js',
+    sourceMapFilename: '[name].js.map',
     library: 'Nametag'
   },
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,12 @@
+const process = require('process')
+const execSync = require('child_process').execSync
 const path = require('path')
 const autoprefixer = require('autoprefixer')
 const Copy = require('copy-webpack-plugin')
 const LicenseWebpackPlugin = require('license-webpack-plugin')
 const webpack = require('webpack')
+
+const GIT_HASH = execSync('git rev-parse HEAD').toString().trim()
 
 // Edit the build targets and embeds below.
 
@@ -92,9 +96,11 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env': {
-        'VERSION': `"${require('./package.json').version}"`
+        'VERSION': `"${require('./package.json').version}"`,
+        'CLIENT_GIT_HASH': GIT_HASH ? JSON.stringify(GIT_HASH) : null
       }
-    })
+    }),
+    new webpack.ExtendedAPIPlugin()
   ],
   resolve: {
     modules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5876,6 +5876,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.17.0.tgz#779457ac7910512c3c2cc9bb6d0a9eeb59a969ec"
+
 raw-body@2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"


### PR DESCRIPTION
Here's a roughly complete Sentry setup for both the client and server. Errors include the git commit and the user's id (on the client side). Once source maps are up and public, Sentry will be able to display full tracebacks for minified client errors.

I needed to change the scope of the server docker volume so that I could pipe git commit hashes through to the backend -- there are other ways to do this, but it seemed like the more straightforward approach.

A few caveats:
 * This may not cover all errors -- it should pick up global errors and errors propagated to express middleware, but there might be some areas of the code that will need extra instrumentation.
 * While testing the backend logging, I have seen Sentry fail to scrub a password in a register request body. I believe it's set up properly, and this code seems bog-standard, so I've asked them for clarification about this.