### PR TITLE
Skip sending emails if no Sendgrid key available

### DIFF
--- a/server/src/email/index.js
+++ b/server/src/email/index.js
@@ -33,6 +33,11 @@ module.exports = ({to, from, template, params}) => {
     ]
   }
 
+  if (!sendgrid.key) {
+    console.log(`No sendgrid API key set. Skipping sending email to ${to}: ${JSON.stringify(mail)}`)
+    return Promise.resolve()
+  }
+
   const request = sg.emptyRequest({
     method: 'POST',
     path: '/v3/mail/send',

--- a/server/src/secrets.sample.json
+++ b/server/src/secrets.sample.json
@@ -29,7 +29,7 @@
     "key":"123"
   },
   "sendgrid": {
-    "key": "stuffandthings"
+    "key": false
   },
   "elasticsearch": {
     "password": "supersecret"


### PR DESCRIPTION
This was breaking the app when I attempted to register a test user. I think this approach is convenient for dev.