### PR TITLE
Skip using prerender-node if no API key set

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -31,7 +31,7 @@ const GIT_HASH = execSync('git rev-parse HEAD', {
 
 process.env.AWS_ACCESS_KEY_ID = config.s3.accessKeyId
 process.env.AWS_SECRET_ACCESS_KEY = config.s3.secretAccessKey
-process.env.PRERENDER_TOKEN = config.prerender.token
+process.env.PRERENDER_TOKEN = config.prerender.token ? config.prerender.token : ''
 
 Raven.config(config.sentry.dsn, {
   tags: {git_commit: GIT_HASH},
@@ -89,7 +89,9 @@ app.use(function (req, res, next) {
 app.use(passport.initialize())
 app.use(passport.session())
 // Prerender pages for SEO optimization
-app.use(require('prerender-node').set('prerenderToken', process.env.PRERENDER_TOKEN))
+if (process.env.PRERENDER_TOKEN) {
+  app.use(require('prerender-node').set('prerenderToken', process.env.PRERENDER_TOKEN))
+}
 
 /* Get rethinkdb connection */
 r.connect({host: 'rethinkdb'})

--- a/server/src/secrets.sample.json
+++ b/server/src/secrets.sample.json
@@ -38,6 +38,6 @@
     "dsn": "https://foo:bar@sentry.io/baz"
   }
   "prerender": {
-    "token": "fluffybutt"
+    "token": false
   }
 }


### PR DESCRIPTION
Bumped into this while updating my repo -- wanted a way to disable this since I didn't have a key.